### PR TITLE
fix: allow ssh connection to gcp vm

### DIFF
--- a/examples/terraform0.12/modules/gcp/main.tf
+++ b/examples/terraform0.12/modules/gcp/main.tf
@@ -7,12 +7,27 @@ resource "google_compute_network" "gcp_network" {
   auto_create_subnetworks = false
 }
 
+resource "google_compute_firewall" "gcp_firewall" {
+  name    = "terraform-firewall-${var.tag_name}"
+  network = google_compute_network.gcp_network.self_link
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+}
+
 resource "google_compute_subnetwork" "gcp_subnetwork" {
   name          = "terraform-${var.tag_name}"
   ip_cidr_range = "10.100.3.0/24"
   region        = var.google_region
   network       = google_compute_network.gcp_network.self_link
 }
+
+resource "google_compute_address" "gcp_public_ip" {
+  name    = "terraform-ip-${var.tag_name}"
+  project = var.google_project
+}
+
 
 resource "google_compute_instance" "gcp_instance" {
   name         = "terraform-vm-${var.tag_name}"
@@ -24,7 +39,10 @@ resource "google_compute_instance" "gcp_instance" {
     }
   }
   network_interface {
-    subnetwork = google_compute_subnetwork.gcp_subnetwork.self_link
+    subnetwork = google_compute_subnetwork.gcp_subnetwork.name
+    access_config {
+      nat_ip = google_compute_address.gcp_public_ip.address
+    }
   }
   metadata = {
     ssh-keys = "ubuntu:${var.ssh_public_key}"


### PR DESCRIPTION
Fix gcp examples module to allow ssh connection to gcp vm via public ip